### PR TITLE
Config and XML Generation Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ skip
 htmlcov
 irida_import/sample.dat
 irida_import/config.ini
-irida_import/irida_import.xml
+irida_import.xml
 irida_import/tests/integration/repos/*
 env
 /.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to irida-galaxy-importer will be documeted in this file.
 * Upgraded to Python 3
 * Removed toolshed support
 * Dependencies needs are now being addressed with bioconda
+* Changes `--config` option to accept a path to to a config file
+* Adds in `--generate_xml` option which is the new option to generate the galaxy tool xml file
+* Adds in `tool_id`, `tool_file`, and `tool_description` options to the config file. These options are used to customize the galaxy tool xml file (e.g. for multiple installations of the tool for multiple Irida installs)
 
 
 ## 1.4.0

--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ expects to access IRIDA resources (but the defaults are fine).
 Once you've set the appropriate connection details in the `config.ini` file, please run the following command from the root of the repository:
 
 ```bash
-python3 -m irida_import.main --config
+python3 -m irida_import.main --generate_xml
 ```
 
 This should print out:
 
 ```
-Successfully configured the XML file!
+Successfully generated the XML file!
 ```
 
 And you should now see a `irida_import.xml` file in the directory which contains the proper details to connect between your IRIDA and Galaxy instances.

--- a/irida_import/config.ini.sample
+++ b/irida_import/config.ini.sample
@@ -9,6 +9,8 @@ xml_file: ../irida_import.xml
 max_waits: 120
 max_client_http_attempts: 10
 client_http_retry_delay: 30
+tool_id: irida_import
+tool_description: server
 
 [IRIDA]
 

--- a/irida_import/config.py
+++ b/irida_import/config.py
@@ -1,12 +1,12 @@
 import configparser
 import os.path
 import re
-import shutil
 
 import xml.etree.ElementTree as ET
 
 
 ET._original_serialize_xml = ET._serialize_xml
+
 
 def serialize_xml_with_CDATA(write, elem, qnames, namespaces, short_empty_elements, **kwargs):
     if elem.tag == 'CDATA':
@@ -14,7 +14,9 @@ def serialize_xml_with_CDATA(write, elem, qnames, namespaces, short_empty_elemen
         return
     return ET._original_serialize_xml(write, elem, qnames, namespaces, short_empty_elements, **kwargs)
 
+
 ET._serialize_xml = ET._serialize['xml'] = serialize_xml_with_CDATA
+
 
 def CDATA(text):
     element = ET.Element("CDATA")
@@ -68,7 +70,7 @@ class Config:
             self.TOKEN_ENDPOINT_SUFFIX = config.get('IRIDA',
                                                     'token_endpoint_suffix')
             self.INITIAL_ENDPOINT_SUFFIX = config.get('IRIDA',
-                                                        'initial_endpoint_suffix')
+                                                      'initial_endpoint_suffix')
 
             irida_loc = config.get('IRIDA', 'irida_url')
             self.TOKEN_ENDPOINT = irida_loc + self.TOKEN_ENDPOINT_SUFFIX
@@ -76,7 +78,6 @@ class Config:
 
             self.CLIENT_ID = config.get('IRIDA', 'client_id')
             self.CLIENT_SECRET = config.get('IRIDA', 'client_secret')
-
 
     def generate_xml(self):
         """
@@ -113,6 +114,8 @@ class Config:
             # https://github.com/phac-nml/irida-galaxy-importer/issues/1
             if param.get('name') == 'galaxyCallbackUrl':
                 previous_value = param.get('value')
-                param.set('value', re.sub(r'TOOL_ID', self.TOOL_ID, re.sub(r'GALAXY_URL', self.GALAXY_URL, previous_value)))
+                new_value = re.sub(r'GALAXY_URL', self.GALAXY_URL, previous_value)
+                new_value = re.sub(r'TOOL_ID', self.TOOL_ID, new_value)
+                param.set('value', new_value)
 
         tree.write(self.TOOL_FILE)

--- a/irida_import/config.py
+++ b/irida_import/config.py
@@ -14,22 +14,22 @@ class Config:
 
     MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 
-    CONFIG_FILE = 'config.ini'
-    CONFIG_PATH = os.path.join(MODULE_DIR, CONFIG_FILE)
+    DEFAULT_CONFIG_FILE = 'config.ini'
+    DEFAULT_CONFIG_PATH = os.path.join(MODULE_DIR, CONFIG_FILE)
 
     XML_FILE_SAMPLE = 'irida_import.xml.sample'
     XML_FILE = 'irida_import.xml'
 
-    def __init__(self):
-        self._load_from_file()
+    def __init__(self, config_file):
+        self._load_from_file(config_file)
 
-    def _load_from_file(self):
+    def _load_from_file(self, config_file):
         """
         Load the tools configuration from the config file
         """
-        with open(self.CONFIG_PATH, 'r') as config_file:
+        with open(config_file, 'r') as config_fh:
             config = configparser.ConfigParser()
-            config.readfp(config_file)
+            config.readfp(config_fh)
 
             # TODO: parse options from command line and config file as a list
             self.ADMIN_KEY = config.get('Galaxy', 'admin_key')
@@ -57,7 +57,7 @@ class Config:
             self.CLIENT_SECRET = config.get('IRIDA', 'client_secret')
 
 
-    def emit_tool_xml(self):
+    def generate_xml(self):
         """
         Emit the configured tools xml
 

--- a/irida_import/irida_import.xml.sample
+++ b/irida_import/irida_import.xml.sample
@@ -1,27 +1,30 @@
-<tool add_galaxy_url="False" force_history_refresh="True" id="irida_import" name="IRIDA" tool_type="data_source" version="2.0.0">
+<tool add_galaxy_url="False" force_history_refresh="True" id="TOOL_ID" name="IRIDA" tool_type="data_source" version="2.0.0">
     <description>server</description>
     <requirements>
-      <requirement type="package" version="0.13.0">bioblend</requirement>
-      <requirement type="package" version="3.0.1">oauthlib</requirement>
-      <requirement type="package" version="2.22.0">requests</requirement>
-      <requirement type="package" version="1.2.0">requests-oauthlib</requirement>
-      <requirement type="package" version="3.8.1">simplejson</requirement>
-      <requirement type="package" version="3.6.7">python</requirement>
+        <requirement type="package" version="0.13.0">bioblend</requirement>
+        <requirement type="package" version="3.0.1">oauthlib</requirement>
+        <requirement type="package" version="2.22.0">requests</requirement>
+        <requirement type="package" version="1.2.0">requests-oauthlib</requirement>
+        <requirement type="package" version="3.8.1">simplejson</requirement>
+        <requirement type="package" version="3.6.7">python</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-      PYTHONPATH=$__tool_directory__ python -m irida_import.main
-	    --json_parameter_file "${output}" --log-file $log_file --history-id "$__app__.security.encode_id($output.history.id)"
+        PYTHONPATH="$__tool_directory__"
+        python -m irida_import.main
+        --json_parameter_file "${output}"
+        --log-file $log_file
+        --history-id "$__app__.security.encode_id($output.history.id)"
     ]]></command>
     <inputs action="http://localhost:8080/projects" check_values="False" method="post">
         <display>import data from IRIDA to Galaxy</display>
-        <param name="galaxyCallbackUrl" type="hidden" value="GALAXY_URL/tool_runner?tool_id=irida_import&amp;runtool_btn=Execute" />
-	<param name="appName" type="hidden" value="Galaxy" />
-	<param name="galaxyClientID" type="hidden" value="webClient" />
+        <param name="galaxyCallbackUrl" type="hidden" value="GALAXY_URL/tool_runner?tool_id=TOOL_ID&amp;runtool_btn=Execute" />
+        <param name="appName" type="hidden" value="Galaxy" />
+        <param name="galaxyClientID" type="hidden" value="webClient" />
     </inputs>
     <uihints minwidth="800" />
     <outputs>
-	    <data format="txt" label="IRIDA Export" name="log_file" />
-	    <data format="auto" hidden="True" name="output" />
+        <data format="txt" label="IRIDA Export" name="log_file" />
+        <data format="auto" hidden="True" name="output" />
     </outputs>
     <options refresh="True" sanitize="False" />
 </tool>

--- a/irida_import/main.py
+++ b/irida_import/main.py
@@ -46,11 +46,9 @@ if __name__ == '__main__':
     try:
         config = Config(args.config)
     except FileNotFoundError:
-        message = ('Error: Could not find config.ini in the irida_importer'
-                   + ' directory!')
+        message = "Error: {} does not exist!".format(args.config)
         logging.info(message)
-        print(message)
-        exit(1)
+        sys.exit(message)
 
     logging.debug("Reading from passed file")
 

--- a/irida_import/main.py
+++ b/irida_import/main.py
@@ -23,10 +23,13 @@ if __name__ == '__main__':
         help='The tool can use a supplied access token instead of querying '
              + 'IRIDA.', metavar='token')
     parser.add_argument(
-        '-c', '--config', action='store_true', default=False, dest='config',
-        help='The tool must configure itself before Galaxy can be started. '
-             + 'Use this option to do so. config.ini should be in the main '
-             + 'irida_import folder.')
+        '-c', '--config', dest='config', default=Config.DEFAULT_CONFIG_PATH,
+        help='The tool requires a config file to run. '
+             + 'By default this is config.ini in the main irida_import folder.')
+    parser.add_argument(
+        '-g', '--generate_xml', action='store_true', default=False, dest='generate_xml',
+        help='The tool must generate a galaxy tool xml file before Galaxy can be started. '
+             + 'Use this option to do so.')
     parser.add_argument(
         '-i', '--history-id', dest='hist_id', default=False,
         help='The tool requires a History ID.')
@@ -41,7 +44,7 @@ if __name__ == '__main__':
                         level=logging.ERROR,
                         filemode="w")
     try:
-        config = Config()
+        config = Config(args.config)
     except FileNotFoundError:
         message = ('Error: Could not find config.ini in the irida_importer'
                    + ' directory!')
@@ -51,9 +54,9 @@ if __name__ == '__main__':
 
     logging.debug("Reading from passed file")
 
-    if args.config:
-        config.emit_tool_xml()
-        message = 'Successfully configured the XML file!'
+    if args.generate_xml:
+        config.generate_xml()
+        message = 'Successfully generated the XML file!'
         logging.info(message)
         print(message)
     else:

--- a/irida_import/tests/integration/bash_scripts/install.sh
+++ b/irida_import/tests/integration/bash_scripts/install.sh
@@ -71,7 +71,7 @@ sed -i "s/^max_waits: .*$/max_waits: 1/" irida_import/config.ini
 sed -i "s|^galaxy_url: http://localhost:8888$|galaxy_url: http://localhost:$galaxy_port|" irida_import/config.ini
 
 echo "Configuring the tool's XML file"
-python -m irida_import.main --config
+python -m irida_import.main --generate_xml
 popd
 
 echo "Adding the tool to Galaxy's tools configuration file."


### PR DESCRIPTION
This addresses #13 

* Changes `--config` option to accept a path to config file.
* Adds in `--generate_xml` option which is the new option to generate the tools xml file
* Adds in `tool_id`, `tool_file`, and `tool_description` to config, which can be used to customize the tool xml (e.g. multiple installations of the tool for multiple iridas)